### PR TITLE
Use low level uart

### DIFF
--- a/lib/romi.c
+++ b/lib/romi.c
@@ -12,21 +12,20 @@
  * This code is based on code in the buckler repo orginally developed by
  * Jeff C. Jensen, Joshua Adkins, and Neal Jackson.
  */
+#include "lib/romi.h"
 #include "kobukiActuator.h"
 #include "kobukiSensor.h"
 #include "kobukiSensorTypes.h"
 #include "kobukiUtilities.h"  // Defines kobukiUARTInit(). 
+#include "buckler.h"
 
 // nRF library files.
 #include "nrf_drv_clock.h"  // Defines nrf_drv_clock_init() and nrf_drv_clock_lfclk_request().
-#include "nrf_uarte.h"
-#include "nrf_serial.h"
+#include "nrfx_uart.h"
 #include "app_timer.h"      // Defines app_timer_init()
 
 // See romi.h for function documentation.
 
-// The following is defined in kobukiUtilities.c, which should probably go away.
-extern const nrf_serial_t * serial_ref;
 
 // NOTE: The implementation here uses code in the buckler repo.
 // Eventually, it should replace all that code.
@@ -34,22 +33,20 @@ extern const nrf_serial_t * serial_ref;
 ///////////////////////////////////////////////////////////////////////////////////////
 //// Private functions. Not documented in romi.h. Used in public functions below.
 
-/**
- * @brief Flush and drain the serial port.
- * @return NRF_SUCCESS if successful.
- */
-int32_t romi_flush_drain_serial() {
-  int32_t status = nrf_serial_flush(serial_ref, NRF_SERIAL_MAX_TIMEOUT);
-  if(status != NRF_SUCCESS) {
-    printf("flush error: %ld\n", status);
-    return status;
-  }
-  status = nrf_serial_rx_drain(serial_ref);
-  if(status != NRF_SUCCESS) {
-    printf("rx drain error: %ld\n", status);
-    return status;
-  }
-  return status;
+
+// UART implementation
+nrfx_uart_t nrfx_uart = NRFX_UART_INSTANCE(0);
+static nrfx_uart_config_t nrfx_uart_cfg = NRFX_UART_DEFAULT_CONFIG;
+
+int romi_uart_init() {
+  nrfx_uart_cfg.pseltxd            = BUCKLER_UART_TX;
+  nrfx_uart_cfg.pselrxd            = BUCKLER_UART_RX;
+  nrfx_uart_cfg.parity             = NRF_UART_PARITY_EXCLUDED;
+  nrfx_uart_cfg.baudrate           = NRF_UART_BAUDRATE_115200;
+  nrfx_uart_cfg.interrupt_priority = NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY;
+
+  // Initialize UART without
+  return nrfx_uart_init(&nrfx_uart, &nrfx_uart_cfg, NULL);
 }
 
 uint8_t romi_checksum_read(uint8_t * buffer, int length){
@@ -82,60 +79,63 @@ int32_t romi_read_serial(uint8_t* packetBuffer, uint8_t len){
 
   state_type state = wait_until_header;
   uint8_t header_buf[2];
-  int32_t status = 0;
   uint8_t payloadSize = 0;
   size_t paylen;
-  size_t aa_count = 0;
   uint8_t calcuatedCS = 0;
   uint8_t byteBuffer = 0;
   size_t bytes_read = 0;
-
-  // Initialization is now occurring in romi_init().
-  // APP_ERROR_CHECK(kobukiUARTInit());
-
-  romi_flush_drain_serial();
+  nrfx_err_t ret;
+  int err_cnt = 0;
+  bool done = false;
+  // Enable reception on UART
+  nrfx_uart_rx_enable(&nrfx_uart);
 
   int num_checksum_failures = 0;
 
-  if (len <= 4) return NRF_ERROR_NO_MEM;
+  if (len <= 4) {
+    ret = NRF_ERROR_NO_MEM;
+    done = true;
+  }
 
-  while(1){
+  while(!done){
    switch(state){
       case wait_until_header:
-        bytes_read = 0;
-        status = nrf_serial_read(serial_ref, header_buf, 2, &bytes_read, 100);
-        if(status != NRF_SUCCESS) {
-          printf("UART error: %ld. Bytes read: %d\n", status, bytes_read);
-          if (aa_count++ < 20) {
-            printf("\ttrying again...\n");
-            romi_flush_drain_serial();
-            break;
-          } else {
-            printf("Failed to receive from robot.\n\tIs robot powered on?\n\tTry unplugging buckler from USB and power cycle robot\n");
-          }
-          return status;
+        ret = nrfx_uart_rx(&nrfx_uart, header_buf, 2);
+        if(ret != NRF_SUCCESS) {
+          nrfx_uart_errorsrc_get(&nrfx_uart);
+          err_cnt++;
+          break;
         }
+
         if (header_buf[0]==0xAA && header_buf[1]==0x55) {
           state = read_length;
         } else {
           state = wait_until_header;
         }
-        aa_count = 0;
         break;
 
       case read_length:
-        status = nrf_serial_read(serial_ref, &payloadSize, sizeof(payloadSize), NULL, 100);
-        if(status != NRF_SUCCESS) {
-          return status;
+        ret = nrfx_uart_rx(&nrfx_uart, &payloadSize, sizeof(payloadSize));
+        if(ret != NRF_SUCCESS) {
+          nrfx_uart_errorsrc_get(&nrfx_uart);
+          err_cnt++;
+          state = wait_until_header;
+          break;
         }
-        if(len < payloadSize+3) return NRF_ERROR_NO_MEM;
+        if(len < payloadSize+3) {
+          done = true;
+          ret = NRF_ERROR_NO_MEM;
+        }
         state = read_payload;
         break;
 
       case read_payload:
-        status = nrf_serial_read(serial_ref, packetBuffer+3, payloadSize+1, &paylen, 100);
-        if(status != NRF_SUCCESS) {
-          return status;
+        ret = nrfx_uart_rx(&nrfx_uart, packetBuffer + 3, payloadSize + 1);
+        if(ret != NRF_SUCCESS) {
+          err_cnt++;
+          nrfx_uart_errorsrc_get(&nrfx_uart);
+          state = wait_until_header;
+          break;
         }
         state = read_checksum;
         break;
@@ -146,26 +146,30 @@ int32_t romi_read_serial(uint8_t* packetBuffer, uint8_t len){
 
         calcuatedCS = romi_checksum_read(packetBuffer, payloadSize + 3);
         byteBuffer=(packetBuffer)[payloadSize+3];
+        done = true;
         if (calcuatedCS == byteBuffer) {
           num_checksum_failures = 0;
-          return NRF_SUCCESS;
+          ret = NRF_SUCCESS;
         } else {
           state = wait_until_header;
           if (num_checksum_failures == 3) {
-            return -1500;
+            ret = -1500;
           }
           num_checksum_failures++;
         }
-        printf("checksum fails: %d\n", num_checksum_failures);
         break;
 
       default:
         break;
     }
+    // If we get too many errors abort the sensor reading.
+    if (ret != NRF_SUCCESS && err_cnt >= 20) {
+      done = true;
+    }
   }
-  // Initialization is now occurring in romi_init().
-  // kobukiUARTUnInit();
-  return status;
+  nrfx_uart_rx_disable(&nrfx_uart);
+
+  return ret;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -174,14 +178,8 @@ int32_t romi_read_serial(uint8_t* packetBuffer, uint8_t len){
 int32_t romi_drive_direct(int16_t left_wheel_speed, int16_t right_wheel_speed) {
     int32_t status = 0;
 
-    // APP_ERROR_CHECK(kobukiUARTInit());
-
-    // Clear the serial port before using to drive the motors.
-    romi_flush_drain_serial();
-
     // FIXME: The following function has a number of problems. Reimplement here.
     status = kobukiDriveDirect(left_wheel_speed, right_wheel_speed);
-    // kobukiUARTUnInit();
 
     return status;
 }
@@ -198,9 +196,8 @@ uint32_t romi_init() {
     APP_ERROR_CHECK(err_code);
   }
 
-  // The original version of this did not initialize the UART. Now we do that here.
-  // This is needed in order to be able to send data to the Romi via romi_drive_direct.
-  APP_ERROR_CHECK(kobukiUARTInit());
+  err_code = romi_uart_init();
+  APP_ERROR_CHECK(err_code);
 
   // Make sure the robot is stopped.
   romi_drive_direct(0, 0);

--- a/lib/romi.h
+++ b/lib/romi.h
@@ -10,10 +10,12 @@
 // To define APP_ERROR_CHECK, a macro that flashes the lights on a robot when
 // something goes wrong.
 #include "app_error.h"
+#include "nrfx_uart.h"
 
 // KobokiSensor_t is defined in the following file.
 #include "kobukiSensorTypes.h"
 
+extern nrfx_uart_t nrfx_uart;
 /**
  * @brief Set the speed of the left and right wheels.
  * The speed is in units of mm/s.

--- a/lib/romi.h
+++ b/lib/romi.h
@@ -10,12 +10,10 @@
 // To define APP_ERROR_CHECK, a macro that flashes the lights on a robot when
 // something goes wrong.
 #include "app_error.h"
-#include "nrfx_uart.h"
 
 // KobokiSensor_t is defined in the following file.
 #include "kobukiSensorTypes.h"
 
-extern nrfx_uart_t nrfx_uart;
 /**
  * @brief Set the speed of the left and right wheels.
  * The speed is in units of mm/s.


### PR DESCRIPTION
This PR does a couple of things:

1. Use nrfx_uart library instead of nrf_serial. It is a lower level API which makes it easier to understand what is happening. This could probably be achieved with nrf_serial also, but I found it easier to work directly with the UART peripheral and not through layers of Nordic code and logic
2. Make romi_sensor_poll a bit more robust. E.g. if we do get a buffer_overrun, clear that error flag. 
3. Copy the kobukiDriveDirect with its dependencies into romi.c. Because I switched out the how to use the UART.
